### PR TITLE
Clean up reactor threadpool after application quit.

### DIFF
--- a/qt5reactor.py
+++ b/qt5reactor.py
@@ -325,6 +325,8 @@ class QtReactor(posixbase.PosixReactorBase):
             self._blockApp = QEventLoop()
         self.runReturn()
         self._blockApp.exec_()
+        if self.threadpool is not None:
+            self.threadpool.stop()
 
     # def sigInt(self, *args):
     #     print('I received a sigint. BAIBAI')


### PR DESCRIPTION
The threadpool may contain threads which have exited. This prevents the process from exiting when the application quits.

Example:

```python
    from sys import argv, exit
    from time import sleep

    from PyQt5.QtWidgets import QDialog, QApplication

    import qt5reactor

    if __name__ == '__main__':
        app = QApplication(argv)
        app.setQuitOnLastWindowClosed(True)

        qt5reactor.install()

        from twisted.internet import reactor

        dialog = QDialog()
        dialog.show()
        dialog.finished.connect(app.quit)

        from twisted.internet import reactor

        def fun():
            for i in range(3):
                sleep(1)
                print('{} second has passed'.format(i))
            print('thread done')

        reactor.callInThread(fun)

        reactor.run()
```

If you close the QDialog after 'thread done' has been printed, the application will fail to quit. This is due to lingering threads in the reactor threadpool.

So after _blockApp.exec_() returns, we check if the threadpool is not None, and if so we .stop() it explicitly.

I bumped into this issue while working on a WAMP + Qt application, and I think in that case it was because the threaded DNS resolver in Twisted had been used, resulting in lingering threads in the threadpool.