### PR TITLE
Stop reactor gracefully on QApplication quit

### DIFF
--- a/qt5reactor.py
+++ b/qt5reactor.py
@@ -325,6 +325,9 @@ class QtReactor(posixbase.PosixReactorBase):
             self._blockApp = QEventLoop()
         self.runReturn()
         self._blockApp.exec_()
+        if self.running:
+            self.stop()
+            self.runUntilCurrent()
 
     # def sigInt(self, *args):
     #     print('I received a sigint. BAIBAI')


### PR DESCRIPTION
If the reactor is running after the `QApplication` has quit, stop it and run all pending timed calls one last time. This will also allow the 'shutdown' system event to trigger properly, which `ReactorBase` [uses internally](https://github.com/twisted/twisted/blob/trunk/twisted/internet/base.py#L961) to stop its threadpool.

Example:

```python
from __future__ import print_function
from sys import argv

from PyQt5.QtWidgets import QApplication
from PyQt5.QtCore import QTimer

import qt5reactor

if __name__ == '__main__':
    app = QApplication(argv)

    qt5reactor.install()

    from twisted.internet import reactor

    reactor.addSystemEventTrigger('before', 'shutdown', lambda: print('before'))
    reactor.addSystemEventTrigger('during', 'shutdown', lambda: print('during'))
    reactor.addSystemEventTrigger('after', 'shutdown', lambda: print('after'))

    QTimer.singleShot(1000, app.quit)  # Quit app after 1 second.

    reactor.run()
```

Before, this would not print anything. After this change it will correctly print:

```
before
during
after
```