### PR TITLE
Fixes sunu/qt5reactor#6

### DIFF
--- a/qt5reactor.py
+++ b/qt5reactor.py
@@ -305,12 +305,11 @@ class QtReactor(posixbase.PosixReactorBase):
         delay = max(delay, 1)
         if not fromqt:
             self.qApp.processEvents(QEventLoop.AllEvents, delay * 1000)
-        if self.timeout() is None:
-            timeout = 0.1
-        elif self.timeout() == 0:
-            timeout = 0
+        t = self.timeout()
+        if t is None:
+            timeout = 0.01
         else:
-            timeout = self.timeout()
+            timeout = min(t, 0.01)
         self._timer.setInterval(timeout * 1000)
         self._timer.start()
 
@@ -325,9 +324,6 @@ class QtReactor(posixbase.PosixReactorBase):
             self._blockApp = QEventLoop()
         self.runReturn()
         self._blockApp.exec_()
-        if self.running:
-            self.stop()
-            self.runUntilCurrent()
 
     # def sigInt(self, *args):
     #     print('I received a sigint. BAIBAI')
@@ -390,10 +386,6 @@ class QtEventReactor(QtReactor):
 
         if closed:
             self._disconnectSelectable(fd, closed, action == 'doRead')
-
-    def timeout(self):
-        t = super(QtEventReactor, self).timeout()
-        return min(t, 0.01)
 
     def iterate(self, delay=None):
         """


### PR DESCRIPTION
Check if timeout() is None and if it is set it to 0.01.

Along the way:
No need to override timeout(), make the needed check in doIteration().
Don't call timeout() multiple times.
Remove the redundant == 0 check in doIteration().