### PR TITLE
Actually specify fromqt=True for QTimer triggered iterate() calls

### DIFF
--- a/qt5reactor.py
+++ b/qt5reactor.py
@@ -195,7 +195,7 @@ class QtReactor(posixbase.PosixReactorBase):
         self._notifiers = {}
         self._timer = QTimer()
         self._timer.setSingleShot(True)
-        self._timer.timeout.connect(self.iterate)
+        self._timer.timeout.connect(self.iterate_qt)
 
         if QCoreApplication.instance() is None:
             # Application Object has not been started yet
@@ -288,9 +288,12 @@ class QtReactor(posixbase.PosixReactorBase):
         """
 
         self.runUntilCurrent()
-        self.doIteration(delay, fromqt)
+        self.doIteration(delay, fromqt=fromqt)
 
     iterate = _iterate
+
+    def iterate_qt(self, delay=None):
+        self.iterate(delay=delay, fromqt=True)
 
     def doIteration(self, delay=None, fromqt=False):
         """
@@ -390,14 +393,14 @@ class QtEventReactor(QtReactor):
         if closed:
             self._disconnectSelectable(fd, closed, action == 'doRead')
 
-    def iterate(self, delay=None):
+    def iterate(self, delay=None, fromqt=False):
         """
         See twisted.internet.interfaces.IReactorCore.iterate.
         """
 
         self.runUntilCurrent()
         self.doEvents()
-        self.doIteration(delay)
+        self.doIteration(delay, fromqt=fromqt)
 
 
 def posixinstall():


### PR DESCRIPTION
Helps avoid #11 across platforms